### PR TITLE
Use Authorization header

### DIFF
--- a/fetch_repo_names.sh
+++ b/fetch_repo_names.sh
@@ -3,10 +3,11 @@
 ORG=$1
 PREFIX=$2
 
-PAGE_COUNT=$(curl -sI "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN" | sed -n -r 's/^link:.*<[^>]*page=([0-9]+)>; rel="last".*$/\1/ip')
+PAGE_COUNT=$(curl -sI -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/orgs/$ORG/repos" | sed -n -r 's/^link:.*<[^>]*page=([0-9]+)>; rel="last".*$/\1/ip')
 
 for ((i=1;i<=PAGE_COUNT;i++)); do
     curl -s \
+    -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&page=$i" | jq -r ".[] | select(.name|startswith(\"$PREFIX\")) | .name" | sed -r "s/$PREFIX(.*)/\1/"
+    "https://api.github.com/orgs/$ORG/repos?page=$i" | jq -r ".[] | select(.name|startswith(\"$PREFIX\")) | .name" | sed -r "s/$PREFIX(.*)/\1/"
 done


### PR DESCRIPTION
... instead of the access_token query parameter, which is deprecated.

https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/