### PR TITLE
Check for empty Page-Count

### DIFF
--- a/fetch_repo_names.sh
+++ b/fetch_repo_names.sh
@@ -5,6 +5,11 @@ PREFIX=$2
 
 PAGE_COUNT=$(curl -sI -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/orgs/$ORG/repos" | sed -n -r 's/^link:.*<[^>]*page=([0-9]+)>; rel="last".*$/\1/ip')
 
+if [ -z "$PAGE_COUNT" ]
+then 
+    PAGE_COUNT=1
+fi
+
 for ((i=1;i<=PAGE_COUNT;i++)); do
     curl -s \
     -H "Authorization: token $GITHUB_TOKEN" \


### PR DESCRIPTION
# Description
If the page count call does not return anything, then the page count is set to one. 
This can counteract the side effect that an organization with only one page of content is not displayed correctly.
